### PR TITLE
install goss into volume to allow to mount into container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,15 @@ FROM alpine:3.4
 MAINTAINER Ahmed Elsabbahy <elsabbahyahmed@yahoo.com>
 
 ENV GOSS_VER v0.2.2
+ENV PATH=/goss:$PATH
 
 # Install goss
 RUN apk add --no-cache --virtual=goss-dependencies curl ca-certificates && \
-    curl -fsSL https://goss.rocks/install | sh && \
+    mkdir /goss && \
+    curl -fsSL https://goss.rocks/install | GOSS_DST=/goss sh && \
     apk del goss-dependencies
+
+VOLUME /goss
 
 # Easily add healtchecks to your image
 # COPY goss/ /goss/

--- a/README.md
+++ b/README.md
@@ -15,6 +15,20 @@ Not sure what Goss is, read these:
 
 This is a simple alpine image with Goss preinstalled on it. Can be used as a base image for your projects to allow for easy health checking.
 
+### Mount example
+
+Create the container
+```
+docker run --name goss aelsabbahy/goss goss
+```
+Create your container and mount goss
+```
+docker run --rm -it --volumes-from goss --name weby nginx
+```
+Run goss inside your container
+```
+docker exec weby /goss/goss autoadd nginx
+```
 
 ### HEALTHCHECK example
 ```


### PR DESCRIPTION
I would use goss in any existing container without using the goss container as base container.
